### PR TITLE
[DDF-476] Fix API documentation errors so that newer javadoc (JDK8) builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 install: mvn install --quiet -DskipTests=true -B
 script: mvn test --quiet -B
 jdk:
+  - openjdk7
   - openjdk6
   - oraclejdk7
-# Build failure on JDK8. DDF JIRA Bug: https://tools.codice.org/jira/browse/DDF-476
-#  - oraclejdk8
+  - oraclejdk8

--- a/core/content-core-api/src/main/java/ddf/content/ContentFramework.java
+++ b/core/content-core-api/src/main/java/ddf/content/ContentFramework.java
@@ -35,18 +35,19 @@ import ddf.content.storage.StorageProvider;
  * <p>
  * General, high-level flow:
  * <ul>
- * <li/>An endpoint will invoke the active {@link ContentFramework}, typically via an OSGi
- * dependency injection framework such as Blueprint
- * <li/>For the {@link #read(ReadRequest) read}, {@link #create(CreateRequest) create},
- * {@link #delete(DeleteRequest) delete}, {@link #update(UpdateRequest) update} methods, the
+ * <li>An endpoint will invoke the active {@link ContentFramework}, typically via an OSGi
+ * dependency injection framework such as Blueprint</li>
+ * <li>For the {@link #read(ReadRequest) read}, {@link #create(CreateRequest, Request.Directive) create},
+ * {@link #delete(DeleteRequest, Request.Directive) delete}, {@link #update(UpdateRequest, Request.Directive) update} methods, the
  * {@link ContentFramework} calls:
  * <ul>
- * <li/>The active {@link StorageProvider}
- * <li/>All "Post" Content Plugins {@link ContentPlugin}
- * <li/>The appropriate {@link Response} is returned to the calling endpoint.
+ * <li>The active {@link StorageProvider}</li>
+ * <li>All "Post" Content Plugins {@link ContentPlugin}</li>
+ * <li>The appropriate {@link Response} is returned to the calling endpoint.</li>
  * </ul>
+ * </li>
  * </ul>
- * </p>
+ * <p>
  * 
  * @author Hugh Rodgers, Lockheed Martin
  * @author ddf.isgs@lmco.com
@@ -55,19 +56,18 @@ public interface ContentFramework {
     /**
      * Creates the {@link ContentItem} in the {@link StorageProvider}.
      * 
-     * <p>
      * <b>Implementations of this method must:</b>
      * <ol>
-     * <li/>Call {@link StorageProvider#create(CreateRequest)} on the registered
-     * {@link StorageProvider}
-     * <li/>Call {@link ContentPlugin#process(CreateResponse)} for each registered
+     * <li>Call {@link StorageProvider#create(CreateRequest)} on the registered
+     * {@link StorageProvider}</li>
+     * <li>Call {@link ContentPlugin#process(CreateResponse)} for each registered
      * {@link ContentPlugin} in order determined by the OSGi SERVICE_RANKING (Descending, highest
-     * first), "daisy chaining" their responses to each other.
+     * first), "daisy chaining" their responses to each other.</li>
      * </ol>
-     * </p>
      * 
      * @param createRequest
      *            the {@link CreateRequest} containing the {@link ContentItem} to be stored
+     * @param directive whether to process, or store-and-process the incoming request
      * @return the {@link CreateResponse} containing the {@link ContentItem} that was created,
      *         including its auto-assigned GUID
      * @throws ContentFrameworkException
@@ -79,17 +79,9 @@ public interface ContentFramework {
     /**
      * Reads a {@link ContentItem} from the {@link StorageProvider}. The {@link ContentItem} must
      * exist in the {@link StorageProvider} for it to be successfully retrieved.
-     * 
-     * *
-     * <p>
-     * <b>Implementations of this method must:</b>
-     * <ol>
-     * <li/>Call {@link StorageProvider#read(ReadRequest)} on the registered {@link StorageProvider}
-     * <li/>Call {@link ContentPlugin#process(ReadResponse)} for each registered
-     * {@link ContentPlugin} in order determined by the OSGi SERVICE_RANKING (Descending, highest
-     * first), "daisy chaining" their responses to each other.
-     * </ol>
-     * </p>
+     *
+     * Implementations of this method must call {@link StorageProvider#read(ReadRequest)} on the
+     * registered {@link StorageProvider}
      * 
      * @param readRequest
      *            the {@link ReadRequest} containing the GUID of the {@link ContentItem} to retrieve
@@ -104,19 +96,18 @@ public interface ContentFramework {
      * exist in the {@link StorageProvider} for it to be successfully updated. The
      * {@link ContentItem} will not be created if it does not already exist.
      * 
-     * <p>
      * <b>Implementations of this method must:</b>
      * <ol>
-     * <li/>Call {@link StorageProvider#update(UpdateRequest)} on the registered
-     * {@link StorageProvider}
-     * <li/>Call {@link ContentPlugin#process(UpdateResponse)} for each registered
+     * <li>Call {@link StorageProvider#update(UpdateRequest)} on the registered
+     * {@link StorageProvider}</li>
+     * <li>Call {@link ContentPlugin#process(UpdateResponse)} for each registered
      * {@link ContentPlugin} in order determined by the OSGi SERVICE_RANKING (Descending, highest
-     * first), "daisy chaining" their responses to each other.
+     * first), "daisy chaining" their responses to each other.</li>
      * </ol>
-     * </p>
      * 
      * @param updateRequest
      *            the {@link UpdateRequest} containing the {@link ContentItem} to be updated
+     * @param directive whether to process, or store-and-process the incoming request
      * @return the {@link UpdateResponse} containing the updated {@link ContentItem}
      * @throws ContentFrameworkException
      *             if problems encountered while updating the {@link ContentItem}
@@ -128,19 +119,18 @@ public interface ContentFramework {
      * Deletes a {@link ContentItem} from the {@link StorageProvider}. The {@link ContentItem} must
      * exist in the {@link StorageProvider} for it to be successfully deleted.
      * 
-     * <p>
      * <b>Implementations of this method must:</b>
      * <ol>
-     * <li/>Call {@link StorageProvider#delete(DeleteRequest)} on the registered
-     * {@link StorageProvider}
-     * <li/>Call {@link ContentPlugin#process(DeleteResponse)} for each registered
+     * <li>Call {@link StorageProvider#delete(DeleteRequest)} on the registered
+     * {@link StorageProvider}</li>
+     * <li>Call {@link ContentPlugin#process(DeleteResponse)} for each registered
      * {@link ContentPlugin} in order determined by the OSGi SERVICE_RANKING (Descending, highest
-     * first), "daisy chaining" their responses to each other.
+     * first), "daisy chaining" their responses to each other.</li>
      * </ol>
-     * </p>
      * 
      * @param deleteRequest
      *            the {@link DeleteRequest} containing the GUID of {@link ContentItem} to be deleted
+     * @param directive whether to process, or store-and-process the incoming request
      * @return the {@link DeleteResponse} containing the status of the {@link ContentItem} deletion
      * @throws ContentFrameworkException
      *             if problems encountered while deleting the {@link ContentItem}

--- a/core/content-core-api/src/main/java/ddf/content/data/ContentItem.java
+++ b/core/content-core-api/src/main/java/ddf/content/data/ContentItem.java
@@ -46,10 +46,12 @@ public interface ContentItem {
      * Sets the URI of the content item.
      * 
      * This is used by the {@link StorageProvider} when the content item is stored in the content
-     * repository and will be of the form "content:<GUID>".
+     * repository and will be of the form <code>content:&lt;GUID&gt;</code>.
      * 
      * Or this is used by the endpoint when the client specifies the content item's location which
      * means the content is stored remote/external to DDF.
+     *
+     * @param uri the URI for the content item
      */
     public void setUri(String uri);
 

--- a/core/content-core-api/src/main/java/ddf/content/operation/CreateRequest.java
+++ b/core/content-core-api/src/main/java/ddf/content/operation/CreateRequest.java
@@ -14,6 +14,7 @@
  **/
 package ddf.content.operation;
 
+import ddf.content.ContentFramework;
 import ddf.content.data.ContentItem;
 
 /**

--- a/core/content-core-api/src/main/java/ddf/content/operation/DeleteRequest.java
+++ b/core/content-core-api/src/main/java/ddf/content/operation/DeleteRequest.java
@@ -14,6 +14,7 @@
  **/
 package ddf.content.operation;
 
+import ddf.content.ContentFramework;
 import ddf.content.data.ContentItem;
 
 /**

--- a/core/content-core-api/src/main/java/ddf/content/operation/ReadRequest.java
+++ b/core/content-core-api/src/main/java/ddf/content/operation/ReadRequest.java
@@ -14,6 +14,9 @@
  **/
 package ddf.content.operation;
 
+import ddf.content.ContentFramework;
+import ddf.content.data.ContentItem;
+
 /**
  * Defines a Read Request object which can be sent to the {@link ContentFramework#read
  * ContentFramework.read}

--- a/core/content-core-api/src/main/java/ddf/content/operation/UpdateRequest.java
+++ b/core/content-core-api/src/main/java/ddf/content/operation/UpdateRequest.java
@@ -14,6 +14,7 @@
  **/
 package ddf.content.operation;
 
+import ddf.content.ContentFramework;
 import ddf.content.data.ContentItem;
 
 /**

--- a/core/content-core-api/src/main/java/ddf/content/storage/StorageProvider.java
+++ b/core/content-core-api/src/main/java/ddf/content/storage/StorageProvider.java
@@ -14,6 +14,10 @@
  **/
 package ddf.content.storage;
 
+import java.io.InputStream;
+
+import ddf.content.ContentFramework;
+import ddf.content.data.ContentItem;
 import ddf.content.operation.CreateRequest;
 import ddf.content.operation.CreateResponse;
 import ddf.content.operation.DeleteRequest;

--- a/core/content-core-api/src/main/java/ddf/content/util/Describable.java
+++ b/core/content-core-api/src/main/java/ddf/content/util/Describable.java
@@ -14,9 +14,11 @@
  **/
 package ddf.content.util;
 
+import ddf.content.storage.StorageProvider;
+
 /**
  * Describable is used to capture a basic description. For an example of a how the Describable
- * interface is used view the {@link StorageProvider} interface and the {@link DescribableImpl}
+ * interface is used view the {@link StorageProvider} interface and the DescribableImpl
  * class.
  * 
  * @author Hugh Rodgers, Lockheed Martin
@@ -33,8 +35,9 @@ public interface Describable {
 
     /**
      * Returns the name, aka ID, of the describable item. The name should be unique for each
-     * instance. <br/>
-     * Example: <code>fsprovider<code> for a {@link StorageProvider} 
+     * instance.
+     *
+     * Example: <code>fsprovider</code> for a {@link StorageProvider} 
      * that stores content to a file system
      * 
      * @return ID of the item

--- a/core/content-core-camelcomponent/src/main/java/ddf/camel/component/content/ContentProducer.java
+++ b/core/content-core-camelcomponent/src/main/java/ddf/camel/component/content/ContentProducer.java
@@ -47,7 +47,7 @@ public class ContentProducer extends DefaultProducer {
 
     /**
      * Constructs the {@link Producer} for the custom Camel ContentComponent. This producer would
-     * map to a Camel <to> route node with a URI like <code>content:framework</code>
+     * map to a Camel <code>&lt;to&gt;</code> route node with a URI like <code>content:framework</code>
      * 
      * @param endpoint
      *            the Camel endpoint that created this consumer

--- a/core/content-core-catalogerplugin/src/main/java/ddf/content/plugin/cataloger/Cataloger.java
+++ b/core/content-core-catalogerplugin/src/main/java/ddf/content/plugin/cataloger/Cataloger.java
@@ -53,7 +53,7 @@ public class Cataloger {
     private CatalogFramework catalogFramework;
 
     /**
-     * @param catalogFramework
+     * @param catalogFramework the parent framework for this Cataloger
      */
     public Cataloger(CatalogFramework catalogFramework) {
         this.catalogFramework = catalogFramework;
@@ -66,8 +66,7 @@ public class Cataloger {
      * @param metacard
      *            the {@link Metacard} to create a catalog entry for
      * @return the catalog ID created in the MDC
-     * @throws SourceUnavailableException
-     * @throws IngestException
+     * @throws PluginExecutionException on failure to create the metacard
      */
     public String createMetacard(Metacard metacard) throws PluginExecutionException {
         logger.trace("ENTERING: createMetacard");

--- a/core/content-core-filestorageprovider/src/main/java/ddf/content/provider/filesystem/FileSystemProvider.java
+++ b/core/content-core-filestorageprovider/src/main/java/ddf/content/provider/filesystem/FileSystemProvider.java
@@ -45,10 +45,9 @@ import ddf.mime.MimeTypeMapper;
 /**
  * The File System Provider provides the implementation to create/update/delete content items as
  * files in the DDF Content Repository. The File System Provider is an implementation of the
- * 
- * @link{StorageProvider interface. When installed, it is invoked by the @link{ContentFramework} to
+ * {@link StorageProvider} interface. When installed, it is invoked by the @link{ContentFramework} to
  *                       create, update, or delete a file in the DDF Content Repository, which is
- *                       located in the <DDF_INSTALL_DIR>/content/store directory.
+ *                       located in the <code>&lt;DDF_INSTALL_DIR&gt;/content/store directory</code>.
  * 
  * @author rodgersh
  * @author ddf.isgs@lmco.com

--- a/core/content-core-impl/src/main/java/ddf/content/data/impl/IncomingContentItem.java
+++ b/core/content-core-impl/src/main/java/ddf/content/data/impl/IncomingContentItem.java
@@ -59,7 +59,7 @@ public class IncomingContentItem implements ContentItem {
      * 
      * @param stream
      *            the {@link ContentItem}'s input stream containing its actual data
-     * @param mimeType
+     * @param mimeTypeRawData
      *            the {@link ContentItem}'s mime type
      */
     public IncomingContentItem(InputStream stream, String mimeTypeRawData, String filename) {
@@ -73,7 +73,7 @@ public class IncomingContentItem implements ContentItem {
      *            the {@link ContentItem}'s GUID
      * @param stream
      *            the {@link ContentItem}'s input stream containing its actual data
-     * @param mimeType
+     * @param mimeTypeRawData
      *            the {@link ContentItem}'s mime type
      */
     public IncomingContentItem(String id, InputStream stream, String mimeTypeRawData) {

--- a/core/content-core-impl/src/main/java/ddf/content/operation/impl/DeleteResponseImpl.java
+++ b/core/content-core-impl/src/main/java/ddf/content/operation/impl/DeleteResponseImpl.java
@@ -48,8 +48,10 @@ public class DeleteResponseImpl extends ResponseImpl<DeleteRequest> implements D
      * 
      * @param request
      *            the original {@link DeleteRequest} that initiated this response
+     * @param contentItem
+     *            the content item to delete
      * @param fileDeleted
-     *            <code>true> if file deleted, <code>false</code> otherwise
+     *            <code>true</code> if file deleted, <code>false</code> otherwise
      */
     public DeleteResponseImpl(DeleteRequest request, ContentItem contentItem, boolean fileDeleted) {
         this(request, contentItem, fileDeleted, null, null);
@@ -61,8 +63,10 @@ public class DeleteResponseImpl extends ResponseImpl<DeleteRequest> implements D
      * 
      * @param request
      *            the original {@link DeleteRequest} that initiated this response
+     * @param contentItem
+     *            the content item to delete
      * @param fileDeleted
-     *            <code>true> if file deleted, <code>false</code> otherwise
+     *            <code>true</code> if file deleted, <code>false</code> otherwise
      * @param responseProperties
      *            the properties associated with this response
      */
@@ -77,8 +81,10 @@ public class DeleteResponseImpl extends ResponseImpl<DeleteRequest> implements D
      * 
      * @param request
      *            the original {@link DeleteRequest} that initiated this response
+     * @param contentItem
+     *            the content item to delete
      * @param fileDeleted
-     *            <code>true> if file deleted, <code>false</code> otherwise
+     *            <code>true</code> if file deleted, <code>false</code> otherwise
      * @param responseProperties
      *            the properties associated with this response
      * @param properties

--- a/core/content-core-impl/src/main/java/ddf/content/operation/impl/ReadResponseImpl.java
+++ b/core/content-core-impl/src/main/java/ddf/content/operation/impl/ReadResponseImpl.java
@@ -47,7 +47,7 @@ public class ReadResponseImpl extends ResponseImpl<ReadRequest> implements ReadR
      *            the original {@link ReadRequest} that initiated this response
      * @param contentItem
      *            the {@link ContentItem} read
-     * @param the
+     * @param responseProperties the
      *            properties associated with the response that are intended for external
      *            distribution
      */
@@ -64,7 +64,7 @@ public class ReadResponseImpl extends ResponseImpl<ReadRequest> implements ReadR
      *            the original {@link ReadRequest} that initiated this response
      * @param contentItem
      *            the {@link ContentItem} read
-     * @param the
+     * @param responseProperties the
      *            properties associated with the response that are intended for external
      *            distribution
      * @param properties

--- a/core/content-core-impl/src/main/java/ddf/content/operation/impl/ResponseImpl.java
+++ b/core/content-core-impl/src/main/java/ddf/content/operation/impl/ResponseImpl.java
@@ -19,8 +19,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import ddf.content.operation.Operation;
 import ddf.content.operation.Request;
 import ddf.content.operation.Response;
+import ddf.content.plugin.ContentPlugin;
+import ddf.content.storage.StorageProvider;
 
 /**
  * Response properties are the properties added specifically to a {@link Response} that are intended
@@ -42,7 +45,7 @@ public class ResponseImpl<T extends Request> extends OperationImpl implements Re
      * 
      * @param request
      *            - the original request
-     * @param properties
+     * @param responseProperties
      *            the properties of the response
      */
     public ResponseImpl(T request, Map<String, String> responseProperties) {


### PR DESCRIPTION
Also fix some warnings and other documentation issues noted during work.
